### PR TITLE
[codex] Rename package with capacitor prefix

### DIFF
--- a/.github/scripts/verify-packed-example.sh
+++ b/.github/scripts/verify-packed-example.sh
@@ -40,13 +40,17 @@ bun run build
 
 case "$platform" in
   android)
-    bunx cap add android
+    if [[ ! -d android ]]; then
+      bunx cap add android
+    fi
     bunx cap sync android
     cd android
     ./gradlew build test
     ;;
   ios)
-    bunx cap add ios
+    if [[ ! -d ios ]]; then
+      bunx cap add ios
+    fi
     bunx cap sync ios
     xcodebuild -project ios/App/App.xcodeproj -scheme App -destination generic/platform=iOS CODE_SIGNING_ALLOWED=NO
     ;;

--- a/CapgoCapacitorNativeMarket.podspec
+++ b/CapgoCapacitorNativeMarket.podspec
@@ -3,7 +3,7 @@ require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 Pod::Spec.new do |s|
-  s.name = 'CapgoNativeMarket'
+  s.name = 'CapgoCapacitorNativeMarket'
   s.version = package['version']
   s.summary = package['description']
   s.license = package['license']

--- a/Package.swift
+++ b/Package.swift
@@ -2,11 +2,11 @@
 import PackageDescription
 
 let package = Package(
-    name: "CapgoNativeMarket",
+    name: "CapgoCapacitorNativeMarket",
     platforms: [.iOS(.v15)],
     products: [
         .library(
-            name: "CapgoNativeMarket",
+            name: "CapgoCapacitorNativeMarket",
             targets: ["NativeMarketPlugin"])
     ],
     dependencies: [

--- a/README.md
+++ b/README.md
@@ -48,13 +48,13 @@ The most complete doc is available here: https://capgo.app/docs/plugins/native-m
 To use npm
 
 ```bash
-npm install @capgo/native-market
+npm install @capgo/capacitor-native-market
 ```
 
 To use yarn
 
 ```bash
-yarn add @capgo/native-market
+yarn add @capgo/capacitor-native-market
 ```
 
 Sync native files
@@ -84,7 +84,7 @@ No configuration required for this plugin
 ## Usage
 
 ```typescript
-import { NativeMarket } from '@capgo/native-market';
+import { NativeMarket } from '@capgo/capacitor-native-market';
 
 /**
  * This method will launch link in Play/App Store.

--- a/bun.lock
+++ b/bun.lock
@@ -3,7 +3,7 @@
   "configVersion": 1,
   "workspaces": {
     "": {
-      "name": "@capgo/native-market",
+      "name": "@capgo/capacitor-native-market",
       "devDependencies": {
         "@capacitor/android": "^8.0.0",
         "@capacitor/cli": "^8.0.0",

--- a/example-app/README.md
+++ b/example-app/README.md
@@ -1,4 +1,4 @@
-# Example App for `@capgo/native-market`
+# Example App for `@capgo/capacitor-native-market`
 
 This Vite project links directly to the local plugin source so you can exercise the native APIs while developing.
 

--- a/example-app/android/app/build.gradle
+++ b/example-app/android/app/build.gradle
@@ -1,10 +1,10 @@
 apply plugin: 'com.android.application'
 
 android {
-    namespace = "app.capgo.native.market"
+    namespace = "app.capgo.nativemarket"
     compileSdk = rootProject.ext.compileSdkVersion
     defaultConfig {
-        applicationId = "app.capgo.native.market"
+        applicationId = "app.capgo.nativemarket"
         minSdkVersion = rootProject.ext.minSdkVersion
         targetSdkVersion = rootProject.ext.targetSdkVersion
         versionCode = 1

--- a/example-app/android/app/src/main/java/app/capgo/nativemarket/MainActivity.java
+++ b/example-app/android/app/src/main/java/app/capgo/nativemarket/MainActivity.java
@@ -1,4 +1,4 @@
-package app.capgo.native.market;
+package app.capgo.nativemarket;
 
 import com.getcapacitor.BridgeActivity;
 

--- a/example-app/android/app/src/main/res/values/strings.xml
+++ b/example-app/android/app/src/main/res/values/strings.xml
@@ -2,6 +2,6 @@
 <resources>
     <string name="app_name">Native Market Example</string>
     <string name="title_activity_main">Native Market Example</string>
-    <string name="package_name">app.capgo.native.market</string>
-    <string name="custom_url_scheme">app.capgo.native.market</string>
+    <string name="package_name">app.capgo.nativemarket</string>
+    <string name="custom_url_scheme">app.capgo.nativemarket</string>
 </resources>

--- a/example-app/bun.lock
+++ b/example-app/bun.lock
@@ -8,7 +8,7 @@
         "@capacitor/android": "^8.0.0",
         "@capacitor/core": "^8.0.0",
         "@capacitor/ios": "^8.0.0",
-        "@capgo/native-market": "file:..",
+        "@capgo/capacitor-native-market": "file:..",
       },
       "devDependencies": {
         "@capacitor/cli": "^8.0.0",
@@ -31,7 +31,7 @@
 
     "@capacitor/ios": ["@capacitor/ios@8.3.1", "", { "peerDependencies": { "@capacitor/core": "^8.3.0" } }, "sha512-BEhLyYYHWJLib4mpaPMaaylbC8meqgxbNYwQJH2svsSLW7yo/hFie+Zoo66a44XnqcMd2tvmAuzimWunXZi/xA=="],
 
-    "@capgo/native-market": ["@capgo/native-market@file:..", { "devDependencies": { "@capacitor/android": "^8.0.0", "@capacitor/cli": "^8.0.0", "@capacitor/core": "^8.0.0", "@capacitor/docgen": "^0.3.1", "@capacitor/ios": "^8.0.0", "@ionic/eslint-config": "^0.4.0", "@ionic/prettier-config": "^4.0.0", "@ionic/swiftlint-config": "^2.0.0", "@types/node": "^24.10.1", "eslint": "^8.57.1", "eslint-plugin-import": "^2.31.0", "husky": "^9.1.7", "prettier": "^3.6.2", "prettier-plugin-java": "^2.7.7", "prettier-pretty-check": "^0.2.0", "rimraf": "^6.1.0", "rollup": "^4.53.2", "swiftlint": "^2.0.0", "typescript": "^5.9.3" }, "peerDependencies": { "@capacitor/core": ">=8.0.0" } }],
+    "@capgo/capacitor-native-market": ["@capgo/capacitor-native-market@file:..", { "devDependencies": { "@capacitor/android": "^8.0.0", "@capacitor/cli": "^8.0.0", "@capacitor/core": "^8.0.0", "@capacitor/docgen": "^0.3.1", "@capacitor/ios": "^8.0.0", "@ionic/eslint-config": "^0.4.0", "@ionic/prettier-config": "^4.0.0", "@ionic/swiftlint-config": "^2.0.0", "@types/node": "^24.10.1", "eslint": "^8.57.1", "eslint-plugin-import": "^2.31.0", "husky": "^9.1.7", "prettier": "^3.6.2", "prettier-plugin-java": "^2.7.7", "prettier-pretty-check": "^0.2.0", "rimraf": "^6.1.0", "rollup": "^4.53.2", "swiftlint": "^2.0.0", "typescript": "^5.9.3" }, "peerDependencies": { "@capacitor/core": ">=8.0.0" } }],
 
     "@chevrotain/cst-dts-gen": ["@chevrotain/cst-dts-gen@11.0.3", "", { "dependencies": { "@chevrotain/gast": "11.0.3", "@chevrotain/types": "11.0.3", "lodash-es": "4.17.21" } }, "sha512-BvIKpRLeS/8UbfxXxgC33xOumsacaeCKAjAeLyOn7Pcp95HiRbrpl14S+9vaZLolnbssPIUuiUd8IvgkRyt6NQ=="],
 

--- a/example-app/capacitor.config.json
+++ b/example-app/capacitor.config.json
@@ -1,5 +1,5 @@
 {
-  "appId": "app.capgo.native.market",
+  "appId": "app.capgo.nativemarket",
   "appName": "Native Market Example",
   "webDir": "dist",
   "plugins": {

--- a/example-app/index.html
+++ b/example-app/index.html
@@ -3,12 +3,12 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>@capgo/native-market Example</title>
+    <title>@capgo/capacitor-native-market Example</title>
     <link rel="stylesheet" href="/src/style.css" />
   </head>
   <body>
     <main class="container">
-      <h1>@capgo/native-market Example</h1>
+      <h1>@capgo/capacitor-native-market Example</h1>
       <p class="lead">Run native plugin APIs with the source linked locally.</p>
       <label for="action-select">Available actions</label>
       <select id="action-select"></select>

--- a/example-app/ios/App/App.xcodeproj/project.pbxproj
+++ b/example-app/ios/App/App.xcodeproj/project.pbxproj
@@ -305,7 +305,7 @@
 				);
 				MARKETING_VERSION = 1.0;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
-				PRODUCT_BUNDLE_IDENTIFIER = app.capgo.native.market;
+				PRODUCT_BUNDLE_IDENTIFIER = app.capgo.nativemarket;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_VERSION = 5.0;
@@ -326,7 +326,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = app.capgo.native.market;
+				PRODUCT_BUNDLE_IDENTIFIER = app.capgo.nativemarket;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";
 				SWIFT_VERSION = 5.0;

--- a/example-app/ios/App/CapApp-SPM/Package.swift
+++ b/example-app/ios/App/CapApp-SPM/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "8.0.0"),
-        .package(name: "CapgoNativeMarket", path: "../../../node_modules/.bun/@capgo+native-market@file+../node_modules/@capgo/native-market")
+        .package(name: "CapgoCapacitorNativeMarket", path: "../../../node_modules/.bun/@capgo+capacitor-native-market@file+../node_modules/@capgo/capacitor-native-market")
     ],
     targets: [
         .target(
@@ -20,7 +20,7 @@ let package = Package(
             dependencies: [
                 .product(name: "Capacitor", package: "capacitor-swift-pm"),
                 .product(name: "Cordova", package: "capacitor-swift-pm"),
-                .product(name: "CapgoNativeMarket", package: "CapgoNativeMarket")
+                .product(name: "CapgoCapacitorNativeMarket", package: "CapgoCapacitorNativeMarket")
             ]
         )
     ]

--- a/example-app/package.json
+++ b/example-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "capacitor-app",
   "version": "1.0.0",
-  "description": "Example Capacitor app for @capgo/native-market",
+  "description": "Example Capacitor app for @capgo/capacitor-native-market",
   "type": "module",
   "keywords": [
     "capacitor",
@@ -16,7 +16,7 @@
     "@capacitor/core": "^8.0.0",
     "@capacitor/android": "^8.0.0",
     "@capacitor/ios": "^8.0.0",
-    "@capgo/native-market": "file:.."
+    "@capgo/capacitor-native-market": "file:.."
   },
   "devDependencies": {
     "@capacitor/cli": "^8.0.0",

--- a/example-app/src/main.js
+++ b/example-app/src/main.js
@@ -1,6 +1,6 @@
 
 import './style.css';
-import { NativeMarket } from '@capgo/native-market';
+import { NativeMarket } from '@capgo/capacitor-native-market';
 
 const plugin = NativeMarket;
 const state = {};

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@capgo/native-market",
+  "name": "@capgo/capacitor-native-market",
   "version": "8.0.28",
   "description": "A native market plugin for linking to google play or app store.",
   "module": "dist/esm/index.js",
@@ -29,23 +29,23 @@
     "ios/Sources",
     "ios/Tests",
     "Package.swift",
-    "CapgoNativeMarket.podspec"
+    "CapgoCapacitorNativeMarket.podspec"
   ],
   "scripts": {
-    "verify": "npm run verify:ios && npm run verify:android && npm run verify:web",
-    "verify:ios": "xcodebuild -scheme CapgoNativeMarket -destination generic/platform=iOS",
+    "verify": "bun run verify:ios && bun run verify:android && bun run verify:web",
+    "verify:ios": "xcodebuild -scheme CapgoCapacitorNativeMarket -destination generic/platform=iOS",
     "verify:android": "cd android && ./gradlew clean build test && cd ..",
-    "verify:web": "npm run build",
-    "lint": "npm run eslint && npm run prettier -- --check && npm run swiftlint -- lint",
-    "fmt": "npm run eslint -- --fix && npm run prettier -- --write && npm run swiftlint -- --fix --format",
+    "verify:web": "bun run build",
+    "lint": "bun run eslint && bun run prettier -- --check && bun run swiftlint -- lint",
+    "fmt": "bun run eslint -- --fix && bun run prettier -- --write && bun run swiftlint -- --fix --format",
     "eslint": "eslint .",
     "prettier": "prettier-pretty-check \"**/*.{css,html,ts,js,java}\" --plugin=prettier-plugin-java",
     "swiftlint": "node-swiftlint",
     "docgen": "docgen --api NativeMarketPlugin --output-readme README.md --output-json dist/docs.json",
-    "build": "npm run clean && npm run docgen && tsc && rollup -c rollup.config.mjs",
+    "build": "bun run clean && bun run docgen && tsc && rollup -c rollup.config.mjs",
     "clean": "rimraf ./dist",
     "watch": "tsc --watch",
-    "prepublishOnly": "npm run build",
+    "prepublishOnly": "bun run build",
     "check:wiring": "node scripts/check-capacitor-plugin-wiring.mjs"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- Rename package metadata from `@capgo/native-market` to `@capgo/capacitor-native-market`.
- Rename the iOS SwiftPM/podspec product from `CapgoNativeMarket` to `CapgoCapacitorNativeMarket`.
- Update docs, example imports, example dependency wiring, and lockfiles to the new package name.

## Validation
- `bun run check:wiring`
- `bun run build`
- `bun run verify:web`
- `bun run verify:ios`
- `bun run lint`

`bun run verify:android` could not run locally because this machine has no Java runtime installed. CI should cover Android.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Platform build script now conditionally installs dependencies to prevent unnecessary recreation

* **Chores**
  * Package renamed to `@capgo/capacitor-native-market`
  * Build tooling switched from npm to Bun
  * Updated platform identifiers across example app configurations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capacitor-native-market/pull/93?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->